### PR TITLE
Allow plain text files as Content to use.

### DIFF
--- a/SharpDenizenTools/MetaHandlers/MetaDocsLoader.cs
+++ b/SharpDenizenTools/MetaHandlers/MetaDocsLoader.cs
@@ -258,7 +258,6 @@ namespace SharpDenizenTools.MetaHandlers
             {
                 zipDataBytes = webClient.GetByteArrayAsync(url).Result;
             }
-
             return zipDataBytes;
         }
 


### PR DESCRIPTION
## Context

I'm already added some custom commands and tags to a server specific implementation using Denizen. However the linter plugin for VS Code doesn't know about them and I need to add the docs somehow.

I already created the Denizen styled docs but instead of browsing the source code I extract the description in a plain text file by a self written annotation processor. The plain text file is distributed without comments. Example for text input:
```
<--[tag]
@attribute <PlayerTag.has_easteregg[<no>]>
@returns ElementTag
@description
Returns whether the player has already solved the easteregg with the specified number
-->

<--[command]
@Name CityTp
@Syntax citytp (id)
@Required 1
@Maximum 1
@Short Teleports the current player to the city
@Group player
@Plugin Terraconia

@Description
Teleports the player to the city, specified by its id

@Usage
Teleport a player to a city
- citytp 270
-->
```
If you have any interest in that annotation processor let me know. Imo there is huge improvement potential to create the docs for commands and tags by using the same annotation for the commands and the docs.

Edit: the full link to the file if you want to test the import:
`https://repo.terraconia.de/artifactory/denizen/terraconia/TerraDenizenExtension/SERVER-SNAPSHOT/TerraDenizenExtension-SERVER-SNAPSHOT.txt`

## Changes in SharpDenizenTools

I modified the Code a little bit to allow plain text additional to zip files. By checking the first two signature bytes the zip file is detected. For other files plain text is used.

This change is fully backwards compatible and doesn't change any existing behavior.