### PR TITLE
Property meta improvements

### DIFF
--- a/SharpDenizenTools/MetaObjects/MetaProperty.cs
+++ b/SharpDenizenTools/MetaObjects/MetaProperty.cs
@@ -24,14 +24,15 @@ namespace SharpDenizenTools.MetaObjects
             docs.Properties.Add(CleanName, this);
             string asTag = $"<{FullName}>";
             string cleanedTag = MetaTag.CleanTag(asTag);
-            string noPrefixDescription = Description.After("Controls");
+            bool hasControls = Description.StartsWithFast("Controls");
+            string cleanedDescription = hasControls ? Description.Substring("Controls".Length) : Description;
             new MetaMechanism()
             {
                 Type = MetaDocs.META_TYPE_MECHANISM,
                 MechName = PropName,
                 MechObject = PropObject,
                 Input = Input,
-                Description = "(Property) Sets" + noPrefixDescription + MechanismDescription,
+                Description = "(Property) " + (hasControls ? "Sets" : "") + cleanedDescription + MechanismDescription,
                 Group = Group ?? "Properties",
                 Warnings = Warnings,
                 Examples = MechanismExamples,
@@ -50,7 +51,7 @@ namespace SharpDenizenTools.MetaObjects
                 BeforeDot = cleanedTag.Before('.'),
                 AfterDotCleaned = cleanedTag.ToLowerFast().After('.'),
                 Returns = Input,
-                Description = "(Property) Returns" + noPrefixDescription + TagDescription,
+                Description = "(Property) " + (hasControls ? "Returns" : "") + cleanedDescription + TagDescription,
                 Mechanism = FullName,
                 Examples = TagExamples,
                 Group = Group ?? "Properties",
@@ -85,10 +86,10 @@ namespace SharpDenizenTools.MetaObjects
         public string Description;
 
         /// <summary>Optional description specific to the property's mechanism.</summary>
-        public string MechanismDescription;
+        public string MechanismDescription = "";
 
         /// <summary>Optional description specific to the property's tag.</summary>
-        public string TagDescription;
+        public string TagDescription = "";
 
         /// <summary>Manual examples for the property's tag. One full script per entry.</summary>
         public List<string> TagExamples = [];

--- a/SharpDenizenTools/MetaObjects/MetaProperty.cs
+++ b/SharpDenizenTools/MetaObjects/MetaProperty.cs
@@ -114,6 +114,10 @@ namespace SharpDenizenTools.MetaObjects
                 case "description":
                     Description = value;
                     return true;
+                case "example":
+                    TagExamples.Add(value);
+                    MechanismExamples.Add(value);
+                    return true;
                 case "tag-example":
                     TagExamples.Add(value);
                     return true;

--- a/SharpDenizenTools/MetaObjects/MetaProperty.cs
+++ b/SharpDenizenTools/MetaObjects/MetaProperty.cs
@@ -24,14 +24,17 @@ namespace SharpDenizenTools.MetaObjects
             docs.Properties.Add(CleanName, this);
             string asTag = $"<{FullName}>";
             string cleanedTag = MetaTag.CleanTag(asTag);
+            string noPrefixDescription = Description.After("Controls");
             new MetaMechanism()
             {
+                Type = MetaDocs.META_TYPE_MECHANISM,
                 MechName = PropName,
                 MechObject = PropObject,
                 Input = Input,
-                Description = "(Property) " + Description,
+                Description = "(Property) Sets" + noPrefixDescription + MechanismDescription,
                 Group = Group ?? "Properties",
                 Warnings = Warnings,
+                Examples = MechanismExamples,
                 Plugin = Plugin,
                 SourceFile = SourceFile,
                 Deprecated = Deprecated,
@@ -41,14 +44,15 @@ namespace SharpDenizenTools.MetaObjects
             }.AddTo(docs);
             new MetaTag()
             {
+                Type = MetaDocs.META_TYPE_TAG,
                 TagFull = asTag,
                 CleanedName = cleanedTag.ToLowerFast(),
                 BeforeDot = cleanedTag.Before('.'),
                 AfterDotCleaned = cleanedTag.ToLowerFast().After('.'),
                 Returns = Input,
-                Description = "(Property) " + Description,
+                Description = "(Property) Returns" + noPrefixDescription + TagDescription,
                 Mechanism = FullName,
-                Examples = Examples,
+                Examples = TagExamples,
                 Group = Group ?? "Properties",
                 Warnings = Warnings,
                 Plugin = Plugin,
@@ -80,8 +84,17 @@ namespace SharpDenizenTools.MetaObjects
         /// <summary>The long-form description.</summary>
         public string Description;
 
-        /// <summary>Manual examples of this tag. One full script per entry.</summary>
-        public List<string> Examples = [];
+        /// <summary>Optional description specific to the property's mechanism.</summary>
+        public string MechanismDescription;
+
+        /// <summary>Optional description specific to the property's tag.</summary>
+        public string TagDescription;
+
+        /// <summary>Manual examples for the property's tag. One full script per entry.</summary>
+        public List<string> TagExamples = [];
+
+        /// <summary>Manual examples for the property's mechanism. One full script per entry.</summary>
+        public List<string> MechanismExamples = [];
 
         /// <summary><see cref="MetaObject.ApplyValue(MetaDocs, string, string)"/></summary>
         public override bool ApplyValue(MetaDocs docs, string key, string value)
@@ -100,8 +113,17 @@ namespace SharpDenizenTools.MetaObjects
                 case "description":
                     Description = value;
                     return true;
-                case "example":
-                    Examples.Add(value);
+                case "tag-example":
+                    TagExamples.Add(value);
+                    return true;
+                case "mechanism-example":
+                    MechanismExamples.Add(value);
+                    return true;
+                case "tag":
+                    TagDescription = '\n' + value;
+                    return true;
+                case "mechanism":
+                    MechanismDescription = '\n' + value;
                     return true;
                 default:
                     return base.ApplyValue(docs, key, value);


### PR DESCRIPTION
## Changes

- When creating the tag and mechanism meta, it will now strip the `Controls` prefix and use `Returns`/`Sets` respectively.
- Now properly sets the created tag & mechanism meta's `MetaType`.
- Added `@tag/mechanism` keys that get appended to the description, for information specific to the tag/mechanism.
- Removed `@example` in favor of `@tag/mechanism-example`, so that examples for both could be added separately.

> [!NOTE]
> Currently it just strips `Controls` if it's there and prefixes it with `Returns`/`Sets`, which will probably be fine? seeing as we're going to update all existing property meta to use this so can just update their description if needed - let me know if there's any different handling you'd prefer though.

> [!NOTE]
> Not sure if `@tag/mechanism` is the best name? doesn't really make it clear it's a description.